### PR TITLE
WIP: Add lidar sensor as an Array of Range Finder Using repclicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Output:
 
 ```
 
+### Feature Requests and Bug reporting
+All the enhacements/missing features/Bugfixes are tracked by [Issues](https://github.com/hello-robot/stretch_mujoco/issues) filed. Please free to file an issue if you would like to report bugs or request a feature addition.
 
 ## Acknowledgment
 The assets in this repository contains significant contributions and efforts from [Kevin Zakka](https://github.com/kevinzakka) and [Google Deepmind](https://github.com/google-deepmind) along with others in Hello Robot Inc. who helped us in modelling Stretch in Mujoco. Thankyou for your contributions.

--- a/stretch.xml
+++ b/stretch.xml
@@ -73,7 +73,6 @@
       </default>
     </default>
   </default>
-
   <asset>
     <texture type="2d" file="hand_crush.png"/>
     <texture type="2d" file="serial.png"/>
@@ -267,9 +266,14 @@
           shellinertia="true"/>
         <geom mesh="link_aruco_left_base" class="collision"/>
       </body>
-      <body name="laser" pos="0.004 0 0.1664" quat="0 0 0 1">
+      <body name="laser" pos="0.004 0 0.1664" euler="0 0 0">
         <geom material="Laser_Black" mesh="laser" class="visual" mass="0.24"/>
         <geom mesh="laser" class="collision"/>
+        <body name="rangefinderarray" pos="0 0 0" euler="0 -1.57 0">
+          <replicate count="360" offset="0 0 0" euler="0.017444444 0 0">
+            <site name="lidar" size="0.0001" pos="0 0 0" euler="0 0 0" rgba="0.5 0.5 0.5 1"/>
+          </replicate>
+        </body>
       </body>
       <body name="link_right_wheel" pos="0 -0.17035 0.0508" quat="1 -1 0 0">
         <joint name="joint_right_wheel" class="wheel"/>
@@ -493,6 +497,7 @@
     <exclude body1="link_gripper_finger_left" body2="link_SG3_gripper_body"/>
     <exclude body1="link_gripper_finger_right" body2="link_SG3_gripper_body"/>
     <exclude body1="rubber_tip_right" body2="rubber_tip_left"/>
+    <exclude body1="laser" body2="rangefinderarray"/>
   </contact>
 
   <tendon>
@@ -528,6 +533,7 @@
   <sensor>
     <gyro name="base_gyro" site="base_imu"/>
     <accelerometer name="base_accel" site="base_imu"/>
+    <rangefinder name="laser" site="lidar" cutoff="12"/>
   </sensor>
 
   <keyframe>


### PR DESCRIPTION
This WIP PR adds a lidar sensor as an array of 360 range finder sensors arranged using the `replicate` feature in Mujoco.
#### Two pending issues to be addressed:

- [ ] Laser range finder cylinder geometry blocks the sensor rays when emitted from the center. Either have to find a way to exclude the geometry from sensor interaction or arrange the sensors on the outer circumference of the lidar cylinder.
- [ ]  Having 360 laser range finder seems to drastically slows the realtime simulation rendering with CPU. Need to find a way to optimize this method.