### PR TITLE
Switch to Using URDF to get world Coordinates Frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .idea/
 *.pyc
 *.egg-info/
+build/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,5 @@
 py_version=39
 known_first_party=stretch
 known_third_party=stretch_body
+known_third_party=stretch_urdf
 line_length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         entry: mypy
         types: [python]
         language: system
-        exclude: ^src/stretch/perception/detection/detic/Detic|^src/stretch/app|^src/stretch_ros2_bridge|^third_party/|^src/stretch/agent|^src/stretch/mapping|^src/stretch/perception|^src/stretch/visualization
+        exclude: ^utils.py
         args:
           - --ignore-missing-imports
           - --install-types

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,3 @@
+import utils
+
 from .stretch_mujoco import StretchMujocoSimulator, models_path, scene_xml_path

--- a/stretch_mujoco.py
+++ b/stretch_mujoco.py
@@ -15,6 +15,8 @@ import numpy as np
 import pkg_resources
 from mujoco import MjData, MjModel
 
+import utils
+
 models_path = pkg_resources.resource_filename("stretch_mujoco", "models")
 default_scene_xml_path = models_path + "/scene.xml"
 
@@ -29,6 +31,7 @@ class StretchMujocoSimulator:
             scene_xml_path = default_scene_xml_path
         self.mjmodel = mujoco.MjModel.from_xml_path(scene_xml_path)
         self.mjdata = mujoco.MjData(self.mjmodel)
+        self.urdf_model = utils.URDFmodel()
 
         self.rgb_renderer = mujoco.Renderer(self.mjmodel, height=480, width=640)
         self.depth_renderer = mujoco.Renderer(self.mjmodel, height=480, width=640)
@@ -101,13 +104,23 @@ class StretchMujocoSimulator:
         return self.get_link_pose("link_grasp_center")
 
     def get_link_pose(self, link_name: str) -> np.ndarray:
-        """Get end effector pose as a 4x4 matrix"""
-        xyz = self.mjdata.body(link_name).xpos
-        rotation = self.mjdata.body(link_name).xmat.reshape(3, 3)
-        pose = np.eye(4)
-        pose[:3, :3] = rotation
-        pose[:3, 3] = xyz
-        return pose
+        """Pose of link in world frame"""
+        cfg = {
+            "wrist_yaw": self.status["wrist_yaw"]["pos"],
+            "wrist_pitch": self.status["wrist_pitch"]["pos"],
+            "wrist_roll": self.status["wrist_roll"]["pos"],
+            "lift": self.status["lift"]["pos"],
+            "arm": self.status["arm"]["pos"],
+            "head_pan": self.status["head_pan"]["pos"],
+            "head_tilt": self.status["head_tilt"]["pos"],
+        }
+        T = self.urdf_model.get_transform(cfg, link_name)
+        base_xyt = self.get_base_pose()
+        base_4x4 = np.eye(4)
+        base_4x4[:3, :3] = utils.Rz(base_xyt[2])
+        base_4x4[:2, 3] = base_xyt[:2]
+        world_coord = np.matmul(T, base_4x4)
+        return world_coord
 
     def pull_status(self) -> Dict[str, Any]:
         """

--- a/stretch_mujoco.py
+++ b/stretch_mujoco.py
@@ -119,7 +119,7 @@ class StretchMujocoSimulator:
         base_4x4 = np.eye(4)
         base_4x4[:3, :3] = utils.Rz(base_xyt[2])
         base_4x4[:2, 3] = base_xyt[:2]
-        world_coord = np.matmul(T, base_4x4)
+        world_coord = np.matmul(base_4x4, T)
         return world_coord
 
     def pull_status(self) -> Dict[str, Any]:

--- a/stretch_mujoco.py
+++ b/stretch_mujoco.py
@@ -175,11 +175,12 @@ class StretchMujocoSimulator:
         self.depth_renderer.update_scene(self.mjdata, "d435i_camera_rgb")
         data["cam_d435i_rgb"] = cv2.rotate(
             cv2.cvtColor(self.rgb_renderer.render(), cv2.COLOR_RGB2BGR),
-            cv2.ROTATE_90_COUNTERCLOCKWISE,
+            cv2.ROTATE_180,
         )
-        data["cam_d435i_depth"] = cv2.rotate(
-            self.depth_renderer.render(), cv2.ROTATE_90_COUNTERCLOCKWISE
-        )
+        data["cam_d435i_depth"] = cv2.rotate(self.depth_renderer.render(), cv2.ROTATE_180)
+
+        # data["cam_d435i_rgb"] = cv2.cvtColor(self.rgb_renderer.render(), cv2.COLOR_RGB2BGR)
+        # data["cam_d435i_depth"] = self.depth_renderer.render()
 
         self.rgb_renderer.update_scene(self.mjdata, "nav_camera_rgb")
         data["cam_nav_rgb"] = cv2.cvtColor(self.rgb_renderer.render(), cv2.COLOR_RGB2BGR)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,94 @@
+import copy
+import importlib.resources as importlib_resources
+
+from pytransform3d.urdf import UrdfTransformManager
+
+pkg_path = str(importlib_resources.files("stretch_urdf"))
+model_name = "SE3"  # RE1V0, RE2V0, SE3
+tool_name = "eoa_wrist_dw3_tool_sg3"  # eoa_wrist_dw3_tool_sg3, tool_stretch_gripper, etc
+urdf_file_path = pkg_path + f"/{model_name}/stretch_description_{model_name}_{tool_name}.urdf"
+mesh_files_directory_path = pkg_path + f"/{model_name}/meshes"
+
+
+def load_urdf(
+    urdf_file_path: str, mesh_files_directory_path: str, whitelist: list = None
+) -> UrdfTransformManager:
+    # read the URDF file and convert it to a string
+    with open(urdf_file_path, "r") as urdf_file:
+        STRETCH_URDF = urdf_file.read()
+
+    # replace the following pattern in the URDF string
+    STRETCH_URDF = STRETCH_URDF.replace("./meshes/", "")
+
+    tm = UrdfTransformManager()
+    tm.load_urdf(STRETCH_URDF, mesh_path=mesh_files_directory_path)
+    return clean_urdf(tm)
+
+
+def clean_urdf(tm: UrdfTransformManager) -> UrdfTransformManager:
+    _tm = copy.deepcopy(tm)
+    for k in tm.transforms:
+        r = False
+        for e in k:
+            if "visual" in e or "collision" in e or "inertia" in e:
+                r = True
+        if r:
+            _tm.remove_transform(k[0], k[1])
+    tm = copy.deepcopy(_tm)
+    return tm
+
+
+def get_stretch_3_urdf():
+    return load_urdf(urdf_file_path, mesh_files_directory_path)
+
+
+class RobotModel:
+    def __init__(self) -> None:
+        self.urdf = get_stretch_3_urdf()
+        self.joints_names = [
+            "joint_wrist_yaw",
+            "joint_wrist_pitch",
+            "joint_wrist_roll",
+            "joint_lift",
+            "joint_arm_l0",
+            "joint_arm_l1",
+            "joint_arm_l2",
+            "joint_arm_l3",
+            "joint_head_pan",
+            "joint_head_tilt",
+            "joint_gripper_finger_left",
+        ]
+
+    def set_config(self, cfg: dict) -> None:
+        self.urdf.set_joint("joint_wrist_yaw", cfg["wrist_yaw"])
+        self.urdf.set_joint("joint_wrist_pitch", cfg["wrist_pitch"])
+        self.urdf.set_joint("joint_wrist_roll", cfg["wrist_roll"])
+        self.urdf.set_joint("joint_lift", cfg["lift"])
+        self.urdf.set_joint("joint_arm_l0", cfg["arm"] / 4)
+        self.urdf.set_joint("joint_arm_l1", cfg["arm"] / 4)
+        self.urdf.set_joint("joint_arm_l2", cfg["arm"] / 4)
+        self.urdf.set_joint("joint_arm_l3", cfg["arm"] / 4)
+        self.urdf.set_joint("joint_head_pan", cfg["head_pan"])
+        self.urdf.set_joint("joint_head_tilt", cfg["head_tilt"])
+        if "gripper" in cfg.keys():
+            self.urdf.set_joint("joint_gripper_finger_left", cfg["gripper"])
+            self.urdf.set_joint("joint_gripper_finger_right", cfg["gripper"])
+
+    def get_transform(self, link1: str, link2: str, cfg: dict):
+        self.set_config(cfg)
+        return self.urdf.get_transform(link1, link2)
+
+
+if __name__ == "__main__":
+    robot = RobotModel()
+    cfg = {
+        "wrist_yaw": 0.0,
+        "wrist_pitch": 0.0,
+        "wrist_roll": 0.0,
+        "lift": 0.6,
+        "arm": 0.0,
+        "head_pan": 0.0,
+        "head_tilt": 0.0,
+    }
+    T = robot.get_transform("base_link", "link_grasp_center", cfg)
+    print(T)

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,8 @@
-import copy
 import importlib.resources as importlib_resources
-from typing import Tuple
+import math
 
 import numpy as np
-from pytransform3d.urdf import UrdfTransformManager
+import urchin as urdf_loader
 
 pkg_path = str(importlib_resources.files("stretch_urdf"))
 model_name = "SE3"  # RE1V0, RE2V0, SE3
@@ -12,60 +11,15 @@ urdf_file_path = pkg_path + f"/{model_name}/stretch_description_{model_name}_{to
 mesh_files_directory_path = pkg_path + f"/{model_name}/meshes"
 
 
-def load_urdf(
-    urdf_file_path: str, mesh_files_directory_path: str, whitelist: list = None
-) -> UrdfTransformManager:
-    # read the URDF file and convert it to a string
-    with open(urdf_file_path, "r") as urdf_file:
-        STRETCH_URDF = urdf_file.read()
-
-    # replace the following pattern in the URDF string
-    STRETCH_URDF = STRETCH_URDF.replace("./meshes/", "")
-
-    tm = UrdfTransformManager()
-    tm.load_urdf(STRETCH_URDF, mesh_path=mesh_files_directory_path)
-    return clean_urdf(tm)
+def Rz(theta):
+    return np.matrix(
+        [[math.cos(theta), -math.sin(theta), 0], [math.sin(theta), math.cos(theta), 0], [0, 0, 1]]
+    )
 
 
-def clean_urdf(tm: UrdfTransformManager) -> UrdfTransformManager:
-    _tm = copy.deepcopy(tm)
-    for k in tm.transforms:
-        r = False
-        for e in k:
-            if "visual" in e or "collision" in e or "inertia" in e:
-                r = True
-        if r:
-            _tm.remove_transform(k[0], k[1])
-    tm = copy.deepcopy(_tm)
-    return tm
-
-
-def get_stretch_3_urdf():
-    return load_urdf(urdf_file_path, mesh_files_directory_path)
-
-
-def decompose_homogeneous_matrix(homogeneous_matrix: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Decomposes a 4x4 homogeneous transformation matrix into its rotation matrix and translation vector components.
-
-    Args:
-        homogeneous_matrix (numpy.ndarray): A 4x4 matrix representing a homogeneous transformation.
-
-    Returns:
-        tuple: A tuple containing:
-            - rotation_matrix : A 3x3 matrix representing the rotation component.
-            - translation_vector : A 1D array of length 3 representing the translation component.
-    """
-    if homogeneous_matrix.shape != (4, 4):
-        raise ValueError("Input matrix must be 4x4")
-    rotation_matrix = homogeneous_matrix[:3, :3]
-    translation_vector = homogeneous_matrix[:3, 3]
-    return rotation_matrix, translation_vector
-
-
-class RobotModel:
+class URDFmodel:
     def __init__(self) -> None:
-        self.urdf = get_stretch_3_urdf()
+        self.urdf = urdf_loader.URDF.load(urdf_file_path, lazy_load_meshes=True)
         self.joints_names = [
             "joint_wrist_yaw",
             "joint_wrist_pitch",
@@ -80,44 +34,20 @@ class RobotModel:
             "joint_gripper_finger_left",
         ]
 
-    def set_config(self, cfg: dict) -> None:
-        self.urdf.set_joint("joint_wrist_yaw", cfg["wrist_yaw"])
-        self.urdf.set_joint("joint_wrist_pitch", cfg["wrist_pitch"])
-        self.urdf.set_joint("joint_wrist_roll", cfg["wrist_roll"])
-        self.urdf.set_joint("joint_lift", cfg["lift"])
-        self.urdf.set_joint("joint_arm_l0", cfg["arm"] / 4)
-        self.urdf.set_joint("joint_arm_l1", cfg["arm"] / 4)
-        self.urdf.set_joint("joint_arm_l2", cfg["arm"] / 4)
-        self.urdf.set_joint("joint_arm_l3", cfg["arm"] / 4)
-        self.urdf.set_joint("joint_head_pan", cfg["head_pan"])
-        self.urdf.set_joint("joint_head_tilt", cfg["head_tilt"])
+    def get_transform(self, cfg: dict, link_name) -> np.ndarray:
+        lk_cfg = {
+            "joint_wrist_yaw": cfg["wrist_yaw"],
+            "joint_wrist_pitch": cfg["wrist_pitch"],
+            "joint_wrist_roll": cfg["wrist_roll"],
+            "joint_lift": cfg["lift"],
+            "joint_arm_l0": cfg["arm"] / 4,
+            "joint_arm_l1": cfg["arm"] / 4,
+            "joint_arm_l2": cfg["arm"] / 4,
+            "joint_arm_l3": cfg["arm"] / 4,
+            "joint_head_pan": cfg["head_pan"],
+            "joint_head_tilt": cfg["head_tilt"],
+        }
         if "gripper" in cfg.keys():
-            self.urdf.set_joint("joint_gripper_finger_left", cfg["gripper"])
-            self.urdf.set_joint("joint_gripper_finger_right", cfg["gripper"])
-
-    def get_transform(self, link1: str, link2: str, cfg: dict) -> Tuple[np.ndarray, np.ndarray]:
-        """
-        Get the transformation matrix between two links given a configuration.
-        Args:
-            link1 (str): The name of the first link.
-            link2 (str): The name of the second link.
-            cfg (dict): The configuration of the robot."""
-
-        self.set_config(cfg)
-        return decompose_homogeneous_matrix(self.urdf.get_transform(link1, link2))
-
-
-if __name__ == "__main__":
-    robot = RobotModel()
-    cfg = {
-        "wrist_yaw": 0.0,
-        "wrist_pitch": 0.0,
-        "wrist_roll": 0.0,
-        "lift": 0.6,
-        "arm": 0.0,
-        "head_pan": 0.0,
-        "head_tilt": 0.0,
-    }
-    R, T = robot.get_transform("link_grasp_center", "base_link", cfg)
-    print(R)
-    print(T)
+            lk_cfg["joint_gripper_finger_left"] = cfg["gripper"]
+            lk_cfg["joint_gripper_finger_right"] = cfg["gripper"]
+        return self.urdf.link_fk(lk_cfg, link=link_name)


### PR DESCRIPTION
This PR switches to using URDF to get the ee, head and camera frames w.r.t to base and then apply the base xyt pose from the mujoco body component. Using mujoco body components for child frames does not seem to work well.