### PR TITLE
Add Base Incremental Position Control 

### DIFF
--- a/stretch_mujoco/config.py
+++ b/stretch_mujoco/config.py
@@ -36,3 +36,5 @@ allowed_position_actuators = [
 ]
 
 base_motion = {"timeout": 15, "default_x_vel": 0.2, "default_r_vel": 1.0}
+
+# TODO: Add params to tune joints response motion profiles

--- a/stretch_mujoco/config.py
+++ b/stretch_mujoco/config.py
@@ -8,3 +8,31 @@ camera_settings = {
 robot_settings = {"wheel_diameter": 0.1016, "wheel_separation": 0.3153}
 
 depth_limits = {"d405": 1, "d435i": 10}
+
+actuator_names = [
+    "arm",
+    "gripper",
+    "head_pan",
+    "head_tilt",
+    "left_wheel_vel",
+    "lift",
+    "right_wheel_vel",
+    "wrist_pitch",
+    "wrist_roll",
+    "wrist_yaw",
+]
+
+allowed_position_actuators = [
+    "arm",
+    "gripper",
+    "head_pan",
+    "head_tilt",
+    "lift",
+    "wrist_pitch",
+    "wrist_roll",
+    "wrist_yaw",
+    "base_rotate",
+    "base_translate",
+]
+
+base_motion = {"timeout": 15, "default_x_vel": 0.2, "default_r_vel": 1.0}

--- a/stretch_mujoco/models/stretch.xml
+++ b/stretch_mujoco/models/stretch.xml
@@ -11,7 +11,7 @@
       <general biastype="affine"/>
       <default class="wheel">
         <joint axis="0 0 1" damping="30" frictionloss="1" armature="0.1" stiffness="0.02"/>
-        <velocity gear="3" kv="100" ctrlrange="-6 6" forcerange="-100 100"/>
+        <velocity gear="3" kv="50" ctrlrange="-6 6" forcerange="-100 100"/>
       </default>
       <default class="lift">
         <joint type="slide" axis="0 0 1" damping="35" stiffness="0.03" armature="0.01" range="0.0 1.1" frictionloss="1.5"/>

--- a/stretch_mujoco/stretch_mujoco.py
+++ b/stretch_mujoco/stretch_mujoco.py
@@ -339,7 +339,6 @@ class StretchMujocoSimulator:
         sign = 1 if theta_inc > 0 else -1
         start_ts = time.perf_counter()
         while abs(start_pose - self.get_base_pose()[-1]) <= abs(theta_inc):
-            print("Tracking...")
             if self._base_in_pos_motion:
                 self.set_base_velocity(
                     0, config.base_motion["default_r_vel"] * sign, _override=True


### PR DESCRIPTION
This PR attempts to provide incremental position control for the base (move_by). The current `stretch.xml` only has velocity control for the base configured. Therefore on move_by() commands for base, it uses threads to asynchronously make the robot track the position or rotation goals with help of the global base pose.