### PR TITLE
Add Robocasa Object Placements

### DIFF
--- a/examples/gamepad_teleop.py
+++ b/examples/gamepad_teleop.py
@@ -17,18 +17,23 @@ def display_camera_feeds():
     # display camera feeds
     while True:
         camera_data = robot_sim.pull_camera_data()
-        cv2.imshow("cam_d405_rgb", camera_data["cam_d405_rgb"])
+        cv2.imshow("cam_d405_rgb", cv2.cvtColor(camera_data["cam_d405_rgb"], cv2.COLOR_RGB2BGR))
         cv2.imshow("cam_d405_depth", get_depth_color_map(camera_data["cam_d405_depth"]))
         cv2.imshow(
-            "cam_d435i_rgb", cv2.rotate(camera_data["cam_d435i_rgb"], cv2.ROTATE_90_CLOCKWISE)
+            "cam_d435i_rgb",
+            cv2.rotate(
+                cv2.cvtColor(camera_data["cam_d435i_rgb"], cv2.COLOR_RGB2BGR),
+                cv2.ROTATE_90_CLOCKWISE,
+            ),
         )
+
         cv2.imshow(
             "cam_d435i_depth",
             cv2.rotate(
                 get_depth_color_map(camera_data["cam_d435i_depth"]), cv2.ROTATE_90_CLOCKWISE
             ),
         )
-        cv2.imshow("cam_nav_rgb", camera_data["cam_nav_rgb"])
+        cv2.imshow("cam_nav_rgb", cv2.cvtColor(camera_data["cam_nav_rgb"], cv2.COLOR_RGB2BGR))
         if cv2.waitKey(1) & 0xFF == ord("q"):
             break
 

--- a/examples/gamepad_teleop.py
+++ b/examples/gamepad_teleop.py
@@ -135,7 +135,8 @@ def main(scene_xml_path: str, robocasa_env: bool, headless: bool):
     if robocasa_env:
         from stretch_mujoco.robocasa_gen import model_generation_wizard
 
-        model, xml = model_generation_wizard()
+        model, xml, objects_info = model_generation_wizard()
+        # breakpoint()
         robot_sim = StretchMujocoSimulator(model=model)
     elif scene_xml_path:
         robot_sim = StretchMujocoSimulator(scene_xml_path=scene_xml_path)

--- a/examples/keyboard_teleop.py
+++ b/examples/keyboard_teleop.py
@@ -69,7 +69,7 @@ def main(scene_xml_path: str, robocasa_env: bool):
     if robocasa_env:
         from stretch_mujoco.robocasa_gen import model_generation_wizard
 
-        model, xml = model_generation_wizard()
+        model, xml, objects_info = model_generation_wizard()
         robot_sim = StretchMujocoSimulator(model=model)
     elif scene_xml_path:
         robot_sim = StretchMujocoSimulator(scene_xml_path=scene_xml_path)

--- a/examples/robocasa_environment.py
+++ b/examples/robocasa_environment.py
@@ -11,7 +11,7 @@ from stretch_mujoco.robocasa_gen import model_generation_wizard
 @click.option("--style", type=int, default=None, help="kitchen style (choose number 0-11)")
 @click.option("--write-to-file", type=str, default=None, help="write to file")
 def main(task: str, layout: int, style: int, write_to_file):
-    model, xml = model_generation_wizard(
+    model, xml, objects_info = model_generation_wizard(
         task=task,
         layout=layout,
         style=style,

--- a/stretch_mujoco/models/stretch.xml
+++ b/stretch_mujoco/models/stretch.xml
@@ -4,7 +4,7 @@
   <!-- <option integrator="implicitfast" impratio="10" cone="elliptic" noslip_iterations="3">
     <flag multiccd="enable"/>
   </option> -->
-  <option integrator="implicitfast" impratio="20">
+  <option integrator="implicitfast" impratio="20" cone="elliptic">
     <flag multiccd="enable"/>
   </option>
   <size njmax="5000" nconmax="5000" />

--- a/stretch_mujoco/robocasa_gen.py
+++ b/stretch_mujoco/robocasa_gen.py
@@ -8,7 +8,6 @@ import numpy as np
 import robosuite
 from robocasa.models.arenas.layout_builder import STYLES
 from robosuite import load_controller_config
-from robosuite.environments.base import MujocoEnv
 from termcolor import colored
 
 from stretch_mujoco import StretchMujocoSimulator
@@ -78,12 +77,14 @@ def model_generation_wizard(
     style: int = None,
     write_to_file: str = None,
     robot_spawn_pose: dict = None,
-) -> Tuple[mujoco.MjModel, str, MujocoEnv]:
+) -> Tuple[mujoco.MjModel, str, dict]:
     """
     Wizard/API to generate a kitchen model for a given task, layout, and style.
     If layout and style are not provided, it will take you through a wizard to choose them in the terminal.
     If robot_spawn_pose is not provided, it will spawn the robot to the default pose from robocasa fixtures.
     You can also write the generated xml model with absolutepaths to a file.
+    The Object placements are made based on the robocasa defined Kitchen task and uses the default randomized
+    placement distribution
     Args:
         task (str): task name
         layout (int): layout id
@@ -91,7 +92,7 @@ def model_generation_wizard(
         write_to_file (str): write to file
         robot_spawn_pose (dict): robot spawn pose {pose: [x, y, z], quat: [x, y, z, w]}
     Returns:
-        Tuple[mujoco.MjModel, str]: model and xml string
+        Tuple[mujoco.MjModel, str, Dict]: model, xml string and Object placements info
     """
     layouts = OrderedDict(
         [
@@ -164,24 +165,31 @@ def model_generation_wizard(
         )
     )
     model = env.sim.model._model
-    object_placements = env.object_placements
     xml = env.sim.model.get_xml()
 
-    if task == "PnPCounterToCab":
-        obj_xml_map = {
-            "obj": "obj_main",
-            "distr_counter": "distr_counter_main",
-            "distr_cab": "distr_cab_main",
+    # Add the object placements to the xml
+    click.secho(f"\nMaking Object Placements for task [{task}]...\n", fg="yellow")
+    object_placements_info = {}
+    for i in range(len(env.object_cfgs)):
+        obj_name = env.object_cfgs[i]["name"]
+        category = env.object_cfgs[i]["info"]["cat"]
+        object_placements = env.object_placements
+        print(
+            f"Placing [Object {i}] (category: {category}, body_name: {obj_name}_main) at "
+            f"pos: {np.round(object_placements[obj_name][0],2)} quat: {np.round(object_placements[obj_name][1],2)}"
+        )
+        xml = xml_modify_body_pos(
+            xml,
+            "body",
+            obj_name + "_main",  # Object name ref in the xml
+            pos=object_placements[obj_name][0],
+            quat=object_placements[obj_name][1],
+        )
+        object_placements_info[obj_name + "_main"] = {
+            "cat": category,
+            "pos": object_placements[obj_name][0],
+            "quat": object_placements[obj_name][1],
         }
-
-        for obj_name in object_placements:
-            xml = xml_modify_body_pos(
-                xml,
-                "body",
-                obj_xml_map[obj_name],
-                pos=object_placements[obj_name][0],
-                quat=object_placements[obj_name][1],
-            )
 
     xml, robot_base_fixture_pose = custom_cleanups(xml)
 
@@ -189,6 +197,7 @@ def model_generation_wizard(
         robot_base_fixture_pose = robot_spawn_pose
 
     # add stretch to kitchen
+    click.secho("\nMaking Robot Placement...\n", fg="yellow")
     xml = add_stretch_to_kitchen(xml, robot_base_fixture_pose)
     model = mujoco.MjModel.from_xml_string(xml)
 
@@ -197,7 +206,7 @@ def model_generation_wizard(
             f.write(xml)
         print(colored(f"Model saved to {write_to_file}", "green"))
 
-    return model, xml, env
+    return model, xml, object_placements_info
 
 
 def custom_cleanups(xml: str) -> Tuple[str, dict]:
@@ -229,7 +238,9 @@ def add_stretch_to_kitchen(xml: str, robot_pose_attrib: dict) -> str:
     """
     Add stretch robot to kitchen xml
     """
-    print("Adding stretch to kitchen at pose: {}".format(robot_pose_attrib))
+    print(
+        f"Adding stretch to kitchen at pos: {robot_pose_attrib['pos']} quat: {robot_pose_attrib['quat']}"
+    )
     stretch_xml_absolute = get_absolute_path_stretch_xml(robot_pose_attrib)
     # add Stretch xml
     xml = insert_line_after_mujoco_tag(
@@ -245,7 +256,7 @@ def add_stretch_to_kitchen(xml: str, robot_pose_attrib: dict) -> str:
 @click.option("--style", type=int, default=None, help="kitchen style (choose number 0-11)")
 @click.option("--write-to-file", type=str, default=None, help="write to file")
 def main(task: str, layout: int, style: int, write_to_file: str):
-    model, xml = model_generation_wizard(
+    model, xml, objects_info = model_generation_wizard(
         task=task,
         layout=layout,
         style=style,

--- a/stretch_mujoco/robocasa_gen.py
+++ b/stretch_mujoco/robocasa_gen.py
@@ -77,6 +77,7 @@ def model_generation_wizard(
     style: int = None,
     write_to_file: str = None,
     robot_spawn_pose: dict = None,
+    object_config: dict = None,
 ) -> Tuple[mujoco.MjModel, str, dict]:
     """
     Wizard/API to generate a kitchen model for a given task, layout, and style.

--- a/stretch_mujoco/robocasa_gen.py
+++ b/stretch_mujoco/robocasa_gen.py
@@ -77,7 +77,6 @@ def model_generation_wizard(
     style: int = None,
     write_to_file: str = None,
     robot_spawn_pose: dict = None,
-    object_config: dict = None,
 ) -> Tuple[mujoco.MjModel, str, dict]:
     """
     Wizard/API to generate a kitchen model for a given task, layout, and style.

--- a/stretch_mujoco/robocasa_gen.py
+++ b/stretch_mujoco/robocasa_gen.py
@@ -264,21 +264,6 @@ def main(task: str, layout: int, style: int, write_to_file: str):
     )
     robot_sim = StretchMujocoSimulator(model=model)
     robot_sim.start()
-    # display camera feeds
-    # try:
-    #     while robot_sim.is_running():
-    #         camera_data = robot_sim.pull_camera_data()
-    #         cv2.imshow("cam_d405_rgb", camera_data["cam_d405_rgb"])
-    #         cv2.imshow("cam_d405_depth", camera_data["cam_d405_depth"])
-    #         cv2.imshow("cam_d435i_rgb", camera_data["cam_d435i_rgb"])
-    #         cv2.imshow("cam_d435i_depth", camera_data["cam_d435i_depth"])
-    #         cv2.imshow("cam_nav_rgb", camera_data["cam_nav_rgb"])
-    #         if cv2.waitKey(1) & 0xFF == ord("q"):
-    #             cv2.destroyAllWindows()
-    #             break
-    # except KeyboardInterrupt:
-    #     robot_sim.stop()
-    #     cv2.destroyAllWindows()
 
 
 if __name__ == "__main__":

--- a/stretch_mujoco/stretch_mujoco.py
+++ b/stretch_mujoco/stretch_mujoco.py
@@ -265,7 +265,7 @@ class StretchMujocoSimulator:
         self.rgb_renderer.update_scene(self.mjdata, "d405_rgb")
         self.depth_renderer.update_scene(self.mjdata, "d405_rgb")
 
-        data["cam_d405_rgb"] = cv2.cvtColor(self.rgb_renderer.render(), cv2.COLOR_RGB2BGR)
+        data["cam_d405_rgb"] = self.rgb_renderer.render()
         data["cam_d405_depth"] = utils.limit_depth_distance(
             self.depth_renderer.render(), config.depth_limits["d405"]
         )
@@ -274,14 +274,14 @@ class StretchMujocoSimulator:
         self.rgb_renderer.update_scene(self.mjdata, "d435i_camera_rgb")
         self.depth_renderer.update_scene(self.mjdata, "d435i_camera_rgb")
 
-        data["cam_d435i_rgb"] = cv2.cvtColor(self.rgb_renderer.render(), cv2.COLOR_RGB2BGR)
+        data["cam_d435i_rgb"] = self.rgb_renderer.render()
         data["cam_d435i_depth"] = utils.limit_depth_distance(
             self.depth_renderer.render(), config.depth_limits["d435i"]
         )
         data["cam_d435i_K"] = self.get_camera_params("d435i_camera_rgb")
 
         self.rgb_renderer.update_scene(self.mjdata, "nav_camera_rgb")
-        data["cam_nav_rgb"] = cv2.cvtColor(self.rgb_renderer.render(), cv2.COLOR_RGB2BGR)
+        data["cam_nav_rgb"] = self.rgb_renderer.render()
         return data
 
     def set_camera_params(self, camera_name: str, fovy: float, res: tuple) -> None:
@@ -518,11 +518,13 @@ def main(
     try:
         while robot_sim.is_running():
             camera_data = robot_sim.pull_camera_data()
-            cv2.imshow("cam_d405_rgb", camera_data["cam_d405_rgb"])
+            cv2.imshow("cam_d405_rgb", cv2.cvtColor(camera_data["cam_d405_rgb"], cv2.COLOR_RGB2BGR))
             cv2.imshow("cam_d405_depth", camera_data["cam_d405_depth"])
-            cv2.imshow("cam_d435i_rgb", camera_data["cam_d435i_rgb"])
+            cv2.imshow(
+                "cam_d435i_rgb", cv2.cvtColor(camera_data["cam_d435i_rgb"], cv2.COLOR_RGB2BGR)
+            )
             cv2.imshow("cam_d435i_depth", camera_data["cam_d435i_depth"])
-            cv2.imshow("cam_nav_rgb", camera_data["cam_nav_rgb"])
+            cv2.imshow("cam_nav_rgb", cv2.cvtColor(camera_data["cam_nav_rgb"], cv2.COLOR_RGB2BGR))
             if cv2.waitKey(1) & 0xFF == ord("q"):
                 cv2.destroyAllWindows()
                 break

--- a/stretch_mujoco/utils.py
+++ b/stretch_mujoco/utils.py
@@ -145,6 +145,25 @@ def xml_remove_tag_by_name(xml_string: str, tag: str, name: str) -> Tuple[str, d
     return ET.tostring(root, encoding="unicode"), removed_body_attrib
 
 
+def xml_modify_body_pos(
+    xml_string: str, tag: str, name: str, pos: np.ndarray, quat: np.ndarray
+) -> str:
+    """
+    Modify the position attribute of a tag with a specified name
+    """
+    # Parse the XML string into an ElementTree
+    root = ET.fromstring(xml_string)
+    # Find the element with body tag and name attribute
+    for elem in root.iter(tag):
+        if elem.get("name") == name:
+            elem.set("pos", " ".join(map(str, pos)))
+            elem.set("quat", " ".join(map(str, quat)))
+            print(
+                f"Found element with name: {name} pos:{','.join(map(str, pos))} quat:{','.join(map(str, quat))}"
+            )
+    return ET.tostring(root, encoding="unicode")
+
+
 def insert_line_after_mujoco_tag(xml_string: str, line_to_insert: str) -> str:
     """
     Insert a new line after the mujoco tag in the XML string

--- a/stretch_mujoco/utils.py
+++ b/stretch_mujoco/utils.py
@@ -158,9 +158,6 @@ def xml_modify_body_pos(
         if elem.get("name") == name:
             elem.set("pos", " ".join(map(str, pos)))
             elem.set("quat", " ".join(map(str, quat)))
-            print(
-                f"Found element with name: {name} pos:{','.join(map(str, pos))} quat:{','.join(map(str, quat))}"
-            )
     return ET.tostring(root, encoding="unicode")
 
 


### PR DESCRIPTION
This PR fixes the task-specific object placements that use the default randomly generated placement distribution fixture provided by Robocasa, which was missing previously. The Object placements should work for any Kitchen task registered from Robocasa [here](https://github.com/robocasa/robocasa/tree/main/robocasa/environments/kitchen), including Single-Stage/Multi-Stage.

-  Object Placements for the task **ClearClutter**
```bash
python -m stretch_mujoco.robocasa_gen --task ClearClutter --layout 0 --style 1
```
<img src=https://github.com/user-attachments/assets/820f0355-6307-487d-917f-9da371772511 width="300" />

```
Placing [Object 0] (category: carrot, body_name: obj_0_main) at pos: [ 0.89 -0.48  0.95] quat: [0.99 0.   0.   0.12]
Placing [Object 1] (category: orange, body_name: obj_1_main) at pos: [ 1.79 -0.53  0.97] quat: [1.   0.   0.   0.07]
Placing [Object 2] (category: bottled_water, body_name: unwashable_obj_0_main) at pos: [ 1.6  -0.6   1.01] quat: [1. 0. 0. 0.]
Placing [Object 3] (category: tray, body_name: receptacle_main) at pos: [ 1.83 -0.24  0.96] quat: [1.   0.   0.   0.02]
```
- Object Placements for the task **ClearingCleaningReceptacles**
```
python -m stretch_mujoco.robocasa_gen --task ClearingCleaningReceptacles --layout 1 --style 0
```
<img src=https://github.com/user-attachments/assets/2169a3ea-aa26-4ff9-be67-e9da8b476ba8 width="300" />

```
Placing [Object 0] (category: mushroom, body_name: obj_0_main) at pos: [ 3.38 -2.23  0.95] quat: [0.12 0.   0.   0.99]
Placing [Object 1] (category: water_bottle, body_name: unwashable_obj_0_main) at pos: [ 3.46 -2.08  1.03] quat: [-0.15  0.    0.    0.99]
Placing [Object 2] (category: bottled_water, body_name: unwashable_obj_1_main) at pos: [ 3.56 -2.21  1.02] quat: [-0.11  0.    0.    0.99]
Placing [Object 3] (category: tray, body_name: receptacle_main) at pos: [ 1.94 -2.36  0.95] quat: [0.1 0.  0.  1. ]
```
- Object Placements for the task **BeverageSorting**
```
python -m stretch_mujoco.robocasa_gen --task BeverageSorting --layout 1 --style 0
```
<img src=https://github.com/user-attachments/assets/68179696-e47a-4a5f-96cf-6eae843f382e width="300" />

```
Placing [Object 0] (category: beer, body_name: alcohol1_main) at pos: [ 1.83 -0.47  1.03] quat: [0.96 0.   0.   0.27]
Placing [Object 1] (category: beer, body_name: alcohol2_main) at pos: [ 1.67 -0.52  0.95] quat: [ 1.  0.  0. -0.]
Placing [Object 2] (category: water_bottle, body_name: non_alcohol1_main) at pos: [ 1.67 -0.3   1.03] quat: [ 0.96  0.    0.   -0.28]
Placing [Object 3] (category: can, body_name: non_alcohol2_main) at pos: [ 1.87 -0.45  0.98] quat: [0.94 0.   0.   0.33
```

Additionally now the [robocasa_gen.model_generation_wizard()]() API unpacks an additional element `object_infos` dictionary which has info on objects placement.
```python
from stretch_mujoco import robocasa_gen
model, xml, objects_info = robocasa_gen.model_generation_wizard(task="ClearClutter", layout=0, style=1)
print(objects_info)
"""
{'obj_0_main': {'cat': 'potato',
                'pos': (0.8259696447487488, -0.4930029668187229, 0.9545504916),
                'quat': array([ 0.9834313 ,  0.        ,  0.        , -0.18128128], dtype=float32)},
 'obj_1_main': {'cat': 'bell_pepper',
                'pos': (0.6341548938033538,  -0.36549036909803156, 0.9615796320000001),
                'quat': array([ 0.9885259 ,  0.        ,  0.        , -0.15105131], dtype=float32)},
 'receptacle_main': {'cat': 'tray',
                     'pos': (1.7366825016273466, -0.23383657879200015, 0.9410638872),
                     'quat': array([ 0.99955136,  0.        ,  0.        , -0.02995089], dtype=float32)},
 'unwashable_obj_0_main': {'cat': 'teapot',
                           'pos': (0.6242942288114184,  -0.4940240521157808, 0.9750751375000001),
                           'quat': array([1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 1.4759951e-04],dtype=float32)},
 'unwashable_obj_1_main': {'cat': 'beer',
                           'pos': (0.7409171927843065, -0.3259462942648694, 1.022),
                           'quat': array([0.9804823 , 0.        , 0.        , 0.19660743], dtype=float32)}}
"""
```
