### PR TITLE
addresses upstream issue #103 kbd conflict

### DIFF
--- a/examples/keyboard_teleop.py
+++ b/examples/keyboard_teleop.py
@@ -116,10 +116,10 @@ def on_release(key, sim: StretchMujocoSimulator):
     global key_buffer, active, ctrl_pressed
     if key==keyboard.Key.ctrl:
         ctrl_pressed = False
-    if not active:
-        return
     if key in key_buffer:
         key_buffer.remove(key)
+    if not active:
+        return
     if isinstance(key, keyboard.KeyCode):
         keyboard_control_release(key.char, sim)
 


### PR DESCRIPTION
By replacing pynput.keyboard with readchar, movement keys will only be active when the launching terminal is in focus. Focusing on the render window will allow using all the kbd shortcuts for numerous features such as wireframe, without interfering with motion commands.